### PR TITLE
Update version to 1.1

### DIFF
--- a/ossn_com.xml
+++ b/ossn_com.xml
@@ -7,9 +7,9 @@
     <license>GNU General Public License, version 2</license>
     <author_url>https://www.softlab24.com/</author_url>
     <license_url>http://opensource-socialnetwork.org/licence/</license_url>
-    <version>1.0</version>
+    <version>1.1</version>
 	<requires>
 		<type>ossn_version</type>
-		<version>4.0</version>
+		<version>4.5</version>
 	</requires>
 </component>


### PR DESCRIPTION
ossn increased to 4.5  because "all-blogs" icon needs Fontawesome 4.7